### PR TITLE
pc - postgres on Heroku, H2 on localhost, Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,30 @@ A project to:
 | Type this | to get this result |
 |-----------|------------|
 | `mvn package` | to make a jar file|
-| `mvn spring-boot:run` | to run the web app|
-| in browser: `http://localhost:8080/greeting/` | to see "Hello, World!" |
-| in browser: `http://localhost:8080/greeting?name=Gauchos` | to see "Hello, Gauchos!"
+| `mvn -P localhost spring-boot:run` | to run the web app on localhost using H2 in memory database, with seed data |
 
-# Using Curl for database
-* Reqirements: Postgres Installed and running on your machine
-* Details for specific machine can be fonud [here](https://www.postgresql.org/download/)
+The `-P localhost` flag uses the `localhost` *profile` defined in the `pom.xml`
 
+This means that you will NOT get the extra `postgres` and `jdbc` dependencies, and as a result, SQL operations will use an
+in-memory H2 database.
+
+The property files are divided as follows:
+
+| Property File | Properties defined |
+|--|--|
+| `/src/main/resources/application.properties` | Always |
+| `/src/main/config/localhost/localhost.properties` | Only when `-P localhost` is passed to `mvn` |
+| `/src/main/config/localhost/heroku.properties` | Only when `-P heroku` is passed to `mvn` |
+
+To ensure that you get a build that uses the `heroku` profile when running on Heroku, you need to specify this in the `Procfile`.
+
+# Using Curl to force CRUD opeations, when running on localhost
+
+The following operations can be used to insert data into the application when running locally.   This does a `POST` request directly
+to the endpoint, putting the needed data into the fields.
 
 To add user to tutor list:
 `curl -d "id=1&fname=phil&lname=conrad&email=pconrad@example.org" -X POST http://localhost:8080/tutors`
-
 
 To add user to Course Offerings List
 `curl -d "id=1&course=CS56&quarter=W19&instructor=pConrad" -X POST http://localhost:8080/courseOfferings/add`

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>edu.ucsb.cs56</groupId>
@@ -59,11 +60,11 @@
             <scope>runtime</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
-        <dependency>
+        <!-- <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.2.8</version>
-        </dependency>
+        </dependency> -->
 
     </dependencies>
 
@@ -145,5 +146,49 @@
             <!-- any further custom report here -->
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>localhost</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources</directory>
+                    </resource>
+                    <resource>
+                        <directory>src/main/config/localhost</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+        <profile>
+            <id>heroku</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources</directory>
+                    </resource>
+                    <resource>
+                        <directory>src/main/config/heroku</directory>
+                    </resource>
+                </resources>
+
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-jdbc</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/config/heroku/heroku.properties
+++ b/src/main/config/heroku/heroku.properties
@@ -1,0 +1,20 @@
+spring.output.ansi.enabled=DETECT
+logging.level.org.hibernate.SQL=debug
+
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name = org.postgresql.Driver
+spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+
+spring.datasource.url=${JDBC_DATABASE_URL}
+spring.datasource.username=${JDBC_DATABASE_USERNAME}
+spring.datasource.password=${JDBC_DATABASE_PASSWORD}
+
+#drop n create table again, good for testing, comment this in production
+spring.jpa.hibernate.ddl-auto=create
+
+#Possible Values: create, create-drop, validate,  update, none
+#See: https://stackoverflow.com/a/42147995
+
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.show-sql=true

--- a/src/main/config/localhost/data.sql
+++ b/src/main/config/localhost/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO course_offering (course,quarter,instructor) VALUES ('CMPSC 56','F19','Conrad');
+INSERT INTO tutor (fname,lname,email) VALUES ('Scott','Chow','scottpchow@example.org');

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,4 @@
 spring.application.name=UCSB Tutor Scheduler
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
-spring.datasource.username=postgres
-spring.datasource.password=password
-spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.show-sql=true
-# This allows auto-creation of the table
 spring.jpa.hibernate.ddl-auto=update
-
-# spring.security.oauth2.client.registration.github.client-id=
-# spring.security.oauth2.client.registration.github.client-secret=
-
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+server.port=${PORT:8080}
 spring.application.name=UCSB Tutor Scheduler
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
In this pull request, we make it possible to
* use H2 on localhost, so that no external database is needed when doing dev work
* seed that database with values via a `data.sql` file (only on localhost)
* use Postgres on Heroku automatically

It is important to always remember to pass the `-P localhost` flag to `mvn` after this pull request is merged; otherwise the default profile will be used, which may fail due to not be able to reach postgres, and not being configured properly for postgres.

This PR also moves the app to Java version 11