### PR TITLE
JL/AL/JM - Added version for mockito to solve 'cannot mock repo interfaces' error

### DIFF
--- a/checkLocalhost.py
+++ b/checkLocalhost.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Check the syntax of the localhost.json file
+
+import json
+import os
+from pprint import pprint
+import sys
+
+try:
+  with open('localhost.json') as json_data:
+     vars = json.load(json_data)
+  back_to_json = json.dumps(vars,indent=2)
+  print(back_to_json)
+  print("JSON looks ok")
+except IOError as e:
+  print("Error reading from localhost.json")
+  print(type(e),e.args)
+except Exception as e:
+  print("Error in JSON: ")
+  print(type(e),e.args)

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,1 @@
+export SPRING_APPLICATION_JSON=`cat localhost.json`

--- a/heroku.json.SAMPLE
+++ b/heroku.json.SAMPLE
@@ -1,0 +1,5 @@
+{
+    "spring.security.oauth2.client.registration.github.client-id":"FILL-IT-IN",
+    "spring.security.oauth2.client.registration.github.client-secret":"FILL-IT-IN",
+    "app_github_org":"ucsb-cs56-f19"
+}

--- a/localhost.json.SAMPLE
+++ b/localhost.json.SAMPLE
@@ -1,0 +1,5 @@
+{
+    "spring.security.oauth2.client.registration.github.client-id":"copy-from-github",
+    "spring.security.oauth2.client.registration.github.client-secret":"copy-from-github",
+    "app_github_org":"ucsb-cs56-f19"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,46 @@
             <version>42.2.8</version>
         </dependency> -->
 
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.thymeleaf.extras/thymeleaf-extras-springsecurity5 -->
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity5</artifactId>
+            <version>3.0.4.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-test -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <!-- For use with github pages, to publish the site to the /docs subdirectory -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/setHerokuEnv.py
+++ b/setHerokuEnv.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+# This file takes the values in heroku.json, and sets those values
+# on a remote app.
+
+# You should invoke this with
+# ./setHerokuEnv.py --app APPNAME
+#
+# Any additional arguments passed after ./setHerokuEnv.py are passed to the "heroku config:set" commandn
+
+import json
+import os
+from pprint import pprint
+import sys
+
+try:
+  with open('heroku.json') as json_data:
+     vars = json.load(json_data)
+  back_to_json = json.dumps(vars)
+  print(back_to_json)
+  print("JSON looks ok")
+except IOError as e:
+  print("Error reading from heroku.json")
+  print(type(e),e.args)
+  sys.exit(1)
+except Exception as e:
+  print("Error in JSON: ")
+  print(type(e),e.args)
+  sys.exit(2)
+
+  
+# https://stackoverflow.com/questions/89228/calling-an-external-command-in-python
+
+addl_args = ""
+for a in sys.argv[1:]:
+   addl_args += (" " + a)
+
+command = "heroku config:set SPRING_APPLICATION_JSON=" + "'" + back_to_json + "'" + addl_args;
+print("\nExecuting: " + command);
+os.system(command);

--- a/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorControllerUnitTest.java
+++ b/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorControllerUnitTest.java
@@ -49,12 +49,12 @@ public class TutorControllerUnitTest {
 
         when(mockedBindingResult.hasErrors()).thenReturn(true);
 
-        assertThat(tutorController.addTutor(tutor, mockedBindingResult, mockedModel)).isEqualTo("add-tutor");
+        assertThat(tutorController.addTutor(tutor, mockedBindingResult, mockedModel)).isEqualTo("tutors/create");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void whenCalledshowUpdateForm_thenIllegalArgumentException() {
-        assertThat(tutorController.showUpdateForm(0, mockedModel)).isEqualTo("update-tutor");
+        assertThat(tutorController.showUpdateForm(0, mockedModel)).isEqualTo("tutors/update");
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TutorControllerUnitTest {
 
         when(mockedBindingResult.hasErrors()).thenReturn(true);
 
-        assertThat(tutorController.updateTutor(1l, tutor, mockedBindingResult, mockedModel)).isEqualTo("update-tutor");
+        assertThat(tutorController.updateTutor(1l, tutor, mockedBindingResult, mockedModel)).isEqualTo("tutors/update");
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Tests were failing because Mockito could not mock repo interfaces. To fix, had to add a version in pom.xml.

Issue #27