### PR TITLE
Kz add tutor level

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/entities/Tutor.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/entities/Tutor.java
@@ -24,16 +24,20 @@ public class Tutor {
     @NotBlank(message = "Email is mandatory")
     private String email;
 
+    @NotBlank(message = "Level is mandatory")
+    private String level;
+
     @OneToMany(mappedBy = "tutor")
     private Set<TutorAssignment> tutorAssignments;
 
     public Tutor() {
     }
 
-    public Tutor(String fname, String lname, String email) {
+    public Tutor(String fname, String lname, String email, String level) {
         this.fname = fname;
         this.lname = lname;
         this.email = email;
+        this.level = level;
     }
 
     public void setId(long id) {
@@ -60,6 +64,10 @@ public class Tutor {
         this.email = email;
     }
 
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
     public String getFname() {
         return fname;
     }
@@ -72,8 +80,12 @@ public class Tutor {
         return email;
     }
 
+    public String getLevel() {
+        return level;
+    }
+
     @Override
     public String toString() {
-        return "Tutor{" + "id=" + id + ", fname=" + fname + ", lname=" + lname + ", email=" + email + '}';
+        return "Tutor{" + "id=" + id + ", fname=" + fname + ", lname=" + lname + ", email=" + email + ", level=" + level + '}';
     }
 }

--- a/src/main/resources/templates/fragments/basic_form.html
+++ b/src/main/resources/templates/fragments/basic_form.html
@@ -34,6 +34,7 @@
                   <th>First Name</th>
                   <th>Last Name</th>
                   <th>Email</th>
+                  <th>Level</th>
                   <th>Edit</th>
                   <th>Delete</th>
                 </tr>
@@ -44,6 +45,7 @@
                   <td th:text="${tutor.fname}"></td>
                   <td th:text="${tutor.lname}"></td>
                   <td th:text="${tutor.email}"></td>
+                  <td th:text="${tutor.level}"></td>
                   <td>
                     <a
                       th:href="@{/tutors/show/{id}(id=${tutor.id})}"

--- a/src/main/resources/templates/fragments/basic_form.html
+++ b/src/main/resources/templates/fragments/basic_form.html
@@ -189,6 +189,7 @@
                   <th>fname</th>
                   <th>lname</th>
                   <th>email</th>
+                  <th>level</th>
                   <th>co.id</th>
                   <th>Course</th>
                   <th>Quarter</th>
@@ -203,6 +204,7 @@
                   <td th:text="${ta.tutor.fname}"></td>
                   <td th:text="${ta.tutor.lname}"></td>
                   <td th:text="${ta.tutor.email}"></td>
+                  <td th:text="${ta.tutor.level}"></td>
                   <td th:text="${ta.courseOffering.id}"></td>
                   <td th:text="${ta.courseOffering.course}"></td>
                   <td th:text="${ta.courseOffering.quarter}"></td>

--- a/src/main/resources/templates/tutors/form.html
+++ b/src/main/resources/templates/tutors/form.html
@@ -44,12 +44,15 @@
       class="text-danger"
     ></span>
   </div>
-  <div>
+  <div class="form-group col-md-6">
+    <label for="level" class="col-form-label">Level</label>
+    <br>
     <select
       name="level"
+      id="level"
       th:field="*{level}"
     >
-      <option value="UNDEFINED">Select Level</option>
+      <option value="" disabled>Select Level</option>
       <option value="190J">190J</option>
       <option value="PAID">PAID</option>
     </select>

--- a/src/main/resources/templates/tutors/form.html
+++ b/src/main/resources/templates/tutors/form.html
@@ -44,4 +44,19 @@
       class="text-danger"
     ></span>
   </div>
+  <div class="form-group col-md-6">
+    <label for="level" class="col-form-label">Level</label>
+    <input
+      type="text"
+      th:field="*{level}"
+      class="form-control"
+      id="level"
+      placeholder="Level"
+    />
+    <span
+      th:if="${#fields.hasErrors('level')}"
+      th:errors="*{level}"
+      class="text-danger"
+    ></span>
+  </div>
 </div>

--- a/src/main/resources/templates/tutors/form.html
+++ b/src/main/resources/templates/tutors/form.html
@@ -51,6 +51,7 @@
       name="level"
       id="level"
       th:field="*{level}"
+      class="form-control"
     >
       <option value="" disabled>Select Level</option>
       <option value="190J">190J</option>

--- a/src/main/resources/templates/tutors/form.html
+++ b/src/main/resources/templates/tutors/form.html
@@ -44,19 +44,19 @@
       class="text-danger"
     ></span>
   </div>
-  <div class="form-group col-md-6">
-    <label for="level" class="col-form-label">Level</label>
-    <input
-      type="text"
+  <div>
+    <select
+      name="level"
       th:field="*{level}"
-      class="form-control"
-      id="level"
-      placeholder="Level"
-    />
+    >
+      <option value="UNDEFINED">Select Level</option>
+      <option value="190J">190J</option>
+      <option value="PAID">PAID</option>
+    </select>
     <span
       th:if="${#fields.hasErrors('level')}"
       th:errors="*{level}"
       class="text-danger"
     ></span>
-  </div>
+</div>
 </div>

--- a/src/main/resources/templates/tutors/readOnlyForm.html
+++ b/src/main/resources/templates/tutors/readOnlyForm.html
@@ -47,4 +47,20 @@
       class="text-danger"
     ></span>
   </div>
+  <div class="form-group col-md-6">
+    <label for="level" class="col-form-label">Level</label>
+    <input
+      readonly
+      type="text"
+      th:field="*{level}"
+      class="form-control"
+      id="level"
+      placeholder="Level"
+    />
+    <span
+      th:if="${#fields.hasErrors('level')}"
+      th:errors="*{level}"
+      class="text-danger"
+    ></span>
+  </div>
 </div>

--- a/src/main/resources/templates/tutors/readOnlyForm.html
+++ b/src/main/resources/templates/tutors/readOnlyForm.html
@@ -49,14 +49,18 @@
   </div>
   <div class="form-group col-md-6">
     <label for="level" class="col-form-label">Level</label>
-    <input
+    <br>
+    <select
       readonly
-      type="text"
+      name="level"
+      id="level"
       th:field="*{level}"
       class="form-control"
-      id="level"
-      placeholder="Level"
-    />
+    >
+      <option value="" disabled>Select Level</option>
+      <option value="190J">190J</option>
+      <option value="PAID">PAID</option>
+    </select>
     <span
       th:if="${#fields.hasErrors('level')}"
       th:errors="*{level}"

--- a/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorControllerUnitTest.java
+++ b/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorControllerUnitTest.java
@@ -30,13 +30,13 @@ public class TutorControllerUnitTest {
 
     @Test
     public void whenCalledAdd_thenCorrect() {
-        Tutor tutor = new Tutor("John", "Smith", "john@domain.com");
+        Tutor tutor = new Tutor("John", "Smith", "john@domain.com", "190J");
         assertThat(tutorController.create(tutor)).isEqualTo("tutors/create");
     }
 
     @Test
     public void whenCalledaddTutorAndValidTutor_thenCorrect() {
-        Tutor tutor = new Tutor("John", "Smith", "john@domain.com");
+        Tutor tutor = new Tutor("John", "Smith", "john@domain.com", "190J");
 
         when(mockedBindingResult.hasErrors()).thenReturn(false);
 
@@ -45,7 +45,7 @@ public class TutorControllerUnitTest {
 
     @Test
     public void whenCalledaddTutorAndInValidTutor_thenCorrect() {
-        Tutor tutor = new Tutor("John", "Smith", "john@domain.com");
+        Tutor tutor = new Tutor("John", "Smith", "john@domain.com", "190J");
 
         when(mockedBindingResult.hasErrors()).thenReturn(true);
 
@@ -59,7 +59,7 @@ public class TutorControllerUnitTest {
 
     @Test
     public void whenCalledupdateTutorAndValidTutor_thenCorrect() {
-        Tutor tutor = new Tutor("John", "Smith", "john@domain.com");
+        Tutor tutor = new Tutor("John", "Smith", "john@domain.com", "190J");
 
         when(mockedBindingResult.hasErrors()).thenReturn(false);
 
@@ -68,7 +68,7 @@ public class TutorControllerUnitTest {
 
     @Test
     public void whenCalledupdateTutorAndInValidTutor_thenCorrect() {
-        Tutor tutor = new Tutor("John", "Smith", "john@domain.com");
+        Tutor tutor = new Tutor("John", "Smith", "john@domain.com", "190J");
 
         when(mockedBindingResult.hasErrors()).thenReturn(true);
 

--- a/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorUnitTest.java
+++ b/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorUnitTest.java
@@ -54,6 +54,6 @@ public class TutorUnitTest {
     @Test
     public void whenCalledtoString_thenCorrect() {
         Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
-        assertThat(tutor.toString()).isEqualTo("Tutor{id=0, fname=Julie, lname=Smith, email=julie@domain.com}");
+        assertThat(tutor.toString()).isEqualTo("Tutor{id=0, fname=Julie, lname=Smith, email=julie@domain.com, level=PAID}");
     }
 }

--- a/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorUnitTest.java
+++ b/src/test/java/edu/ucsb/cs56/ucsb_courses_search/TutorUnitTest.java
@@ -10,27 +10,27 @@ public class TutorUnitTest {
 
     @Test
     public void whenCalledGetFName_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
 
         assertThat(tutor.getFname()).isEqualTo("Julie");
     }
 
     @Test
     public void whenCalledGetLName_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
 
         assertThat(tutor.getLname()).isEqualTo("Smith");
     }
 
     @Test
     public void whenCalledGetEmail_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
         assertThat(tutor.getEmail()).isEqualTo("julie@domain.com");
     }
 
     @Test
     public void whenCalledSetFname_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
 
         tutor.setFname("John");
 
@@ -39,21 +39,21 @@ public class TutorUnitTest {
 
     @Test
     public void whenCalledSetLname_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
         tutor.setLname("Jones");
         assertThat(tutor.getLname()).isEqualTo("Jones");
     }
 
     @Test
     public void whenCalledSetEmail_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
         tutor.setEmail("julie@otherdomain.com");
         assertThat(tutor.getEmail()).isEqualTo("julie@otherdomain.com");
     }
 
     @Test
     public void whenCalledtoString_thenCorrect() {
-        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com");
+        Tutor tutor = new Tutor("Julie", "Smith", "julie@domain.com", "PAID");
         assertThat(tutor.toString()).isEqualTo("Tutor{id=0, fname=Julie, lname=Smith, email=julie@domain.com}");
     }
 }


### PR DESCRIPTION
Who worked on this: Katelyn Zhang

In this PR, a drop down selection menu for a tutor's field named level was added to the create tutors page. The two options in this selection menu are "190J" and "PAID".

Since there is no submit button on the tutors page, and that story is assigned to the other group, I was not able to test if selecting the options would actually set the level variable and show up on the tutors table.

[EDIT] Used to fail the Travis CI checks due to a unit test that was not updated to reflect the addition of the level field.