### PR TITLE
5pm-Tutors Added an 'Add Tutors' Button

### DIFF
--- a/src/main/resources/templates/tutors/create.html
+++ b/src/main/resources/templates/tutors/create.html
@@ -31,6 +31,7 @@
             method="post"
           >
             <div th:replace="tutors/form.html"></div>
+            <input type="submit" class="btn btn-primary" value="Add New Tutor">
           </form>
         </div>
       </div>


### PR DESCRIPTION
References Issue #14 
Adds a button so that tutors can be added

This is before we tried to add tests for the button. When we were trying to add the tests, Andrew, April, Jayleen, and Jacqui all worked on trying to get the tests to pass on Travis CI, but were blocked. This is a pull request of just adding the button, which was fixing the original bug that we were all trying to fix.