### PR TITLE
kz - added level field to data.sql to avoid empty level column

### DIFF
--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,9 +2,9 @@ INSERT INTO course_offering (course,quarter,instructor) VALUES ('CMPSC 16','F19'
 INSERT INTO course_offering (course,quarter,instructor) VALUES ('CMPSC 160','F19','Ding');
 INSERT INTO course_offering (course,quarter,instructor) VALUES ('CMPSC 130A','W20','Koc');
 INSERT INTO course_offering (course,quarter,instructor) VALUES ('CMPSC 130B','W20','Lokshtanov');
-INSERT INTO tutor (fname,lname,email) VALUES ('Scott','Chow','scottpchow@example.org');
-INSERT INTO tutor (fname,lname,email) VALUES ('Zach','Sisco','zachsisco@example.org');
-INSERT INTO tutor (fname,lname,email) VALUES ('Yinon','Rousso','yinonRousso@example.org');
-INSERT INTO tutor (fname,lname,email) VALUES ('Kate','Perkins','kateperkins@example.org');
-INSERT INTO tutor (fname,lname,email) VALUES ('George','Kripac','Georgekripac@example.org');
+INSERT INTO tutor (fname,lname,email,level) VALUES ('Scott','Chow','scottpchow@example.org','PAID');
+INSERT INTO tutor (fname,lname,email,level) VALUES ('Zach','Sisco','zachsisco@example.org','PAID');
+INSERT INTO tutor (fname,lname,email,level) VALUES ('Yinon','Rousso','yinonRousso@example.org','109J');
+INSERT INTO tutor (fname,lname,email,level) VALUES ('Kate','Perkins','kateperkins@example.org','109J');
+INSERT INTO tutor (fname,lname,email,level) VALUES ('George','Kripac','Georgekripac@example.org','109J');
 INSERT INTO tutor_assignment (course_offering_id,tutor_id) VALUES (1,1);


### PR DESCRIPTION
In this PR, levels for the tutors were added in data.sql so that when testing or running, the level column is not empty.