### PR TITLE
tk - Allow users to create new course offerings

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/entities/CourseOffering.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/entities/CourseOffering.java
@@ -37,11 +37,11 @@ public class CourseOffering {
         this.instructor = instructor;
     }
 
-    public void setId(long id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
-    public long getId() {
+    public Long getId() {
         return id;
     }
 


### PR DESCRIPTION
Initially users were unable to create courses. Clicking on the add courses button resulted in an 500 Internal Server Error. This PR allows users to create new course offerings for a quarter.