### PR TITLE
kz - fixed missing level of tutors in level column of tutors table

### DIFF
--- a/src/main/resources/templates/fragments/basic_form.html
+++ b/src/main/resources/templates/fragments/basic_form.html
@@ -52,6 +52,7 @@
                   <td th:text="${tutor.fname}"></td>
                   <td th:text="${tutor.lname}"></td>
                   <td th:text="${tutor.email}"></td>
+                  <td th:text="${tutor.level}"></td>
                   <td>
                     <a
                       th:href="@{/tutors/show/{id}(id=${tutor.id})}"


### PR DESCRIPTION
In this PR, the level of each tutor was added back in to the table to make the columns aligned correctly again.