### PR TITLE
Jm/aq move tables to tabs

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/RoomsController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/RoomsController.java
@@ -27,6 +27,11 @@ public class RoomsController {
     public RoomsController(RoomsRepository roomsRepository) {
         this.roomsRepository = roomsRepository;
     }
+    
+    @GetMapping("/rooms/roomsPage")
+    public String roomsPage(Rooms rooms) {
+        return "rooms/roomsPage";
+    }
 
     @GetMapping("/rooms/create")
     public String create(Rooms rooms) {

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/TimeSlotController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/TimeSlotController.java
@@ -28,6 +28,11 @@ public class TimeSlotController {
         this.timeSlotRepository = timeSlotRepository;
     }
 
+    @GetMapping("/timeSlots/timeSlotsPage")
+    public String timeSlotsPage(Model model) {
+        return "timeSlots/timeSlotsPage";
+    }
+
     @GetMapping("/timeSlots/create")
     public String create(TimeSlot timeSlot) {
         return "timeSlots/create";

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/TutorController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/TutorController.java
@@ -26,6 +26,11 @@ public class TutorController {
         this.tutorRepository = tutorRepository;
     }
 
+    @GetMapping("/tutors/tutorsPage")
+    public String tutorsPage(Model model) {
+        return "tutors/tutorsPage";
+    }
+
     @GetMapping("/tutors/create")
     public String create(Tutor tutor) {
         return "tutors/create";

--- a/src/main/resources/templates/courseOfferings/mainCourse.html
+++ b/src/main/resources/templates/courseOfferings/mainCourse.html
@@ -24,62 +24,10 @@
 
 
   <body>
-    <div class = container>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <a class="navbar-brand" href="/">Sample-Website</a>
-    <!-- Button to collapse/expand navbar when it doesn't fit on the screen-->
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
-      <ul class="navbar-nav mr-auto">
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Tutors
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <a class="dropdown-item" href="#">Action</a>
-              <a class="dropdown-item" href="#">Another action</a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="#">Something else here</a>
-            </div>
-          </li>
-          <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Course Offerings
-              </a>
-              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <a class="dropdown-item" href="/courseOfferings/mainCourse">Action</a>            
-                <a class="dropdown-item" href="#">Another action</a>
-                <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="#">Something else here</a>
-              </div>
-            </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Time Slots
-              </a>
-              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <a class="dropdown-item" href="#">Action</a>
-                <a class="dropdown-item" href="#">Another action</a>
-                <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="#">Something else here</a>
-              </div>
-            </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Rooms
-              </a>
-              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <a class="dropdown-item" href="#">Action</a>
-                <a class="dropdown-item" href="#">Another action</a>
-                <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="#">Something else here</a>
-              </div>
-            </li>
-        </ul>
-  </div>
-</nav>
+    <div class="container">
+      <div th:replace="fragments/bootstrap_nav_header.html"></div>
+      <!DOCTYPE html>
+      <html xmlns:th="http://www.thymeleaf.org">
     <div th:switch="${courseOfferings}" class="container my-5">
       <div class="row">
         <div class="col-md-6">
@@ -176,6 +124,8 @@
         </div>
       </div>
     </div>
-    </div>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
   </body>
 </html>

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -49,7 +49,7 @@
                   Rooms
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="#">Action</a>
+                  <a class="dropdown-item" href="rooms/roomsPage">Action</a>
                   <a class="dropdown-item" href="#">Another action</a>
                   <div class="dropdown-divider"></div>
                   <a class="dropdown-item" href="#">Something else here</a>

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -3,7 +3,7 @@
 <!-- See https://getbootstrap.com/docs/4.0/components/navbar/ for documentation on how to adjust HTML below -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
 
-  <a class="navbar-brand" href="/">Sample-Website</a>
+  <a class="navbar-brand" href="/">Tutor Scheduler</a>
   <!-- Button to collapse/expand navbar when it doesn't fit on the screen-->
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup"
       aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
@@ -11,50 +11,10 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <ul class="navbar-nav mr-auto">
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Tutors
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <a class="dropdown-item" href="tutors/tutorsPage">Action</a>
-              <a class="dropdown-item" href="#">Another action</a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="#">Something else here</a>
-            </div>
-          </li>
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Course Offerings
-                </a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="/courseOfferings/mainCourse">Action</a>
-                  <a class="dropdown-item" href="#">Another action</a>
-                  <div class="dropdown-divider"></div>
-                  <a class="dropdown-item" href="#">Something else here</a>
-                </div>
-              </li>
-              <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Time Slots
-                </a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="/timeSlots/timeSlotsPage">Action</a>
-                  <a class="dropdown-item" href="#">Another action</a>
-                  <div class="dropdown-divider"></div>
-                  <a class="dropdown-item" href="#">Something else here</a>
-                </div>
-              </li>
-              <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Rooms
-                </a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="rooms/roomsPage">Action</a>
-                  <a class="dropdown-item" href="#">Another action</a>
-                  <div class="dropdown-divider"></div>
-                  <a class="dropdown-item" href="#">Something else here</a>
-                </div>
-              </li>
+        <a class="nav-link" href="/tutors/tutorsPage">Tutors</a>
+        <a class="nav-link" href="/courseOfferings/mainCourse">Course Offerings</a>
+        <a class="nav-link" href="/timeSlots/timeSlotsPage">Time Slots</a>
+        <a class="nav-link" href="/rooms/roomsPage">Rooms</a>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <li th:if="${isLoggedIn}">

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -38,7 +38,7 @@
                   Time Slots
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                  <a class="dropdown-item" href="#">Action</a>
+                  <a class="dropdown-item" href="/timeSlots/timeSlotsPage">Action</a>
                   <a class="dropdown-item" href="#">Another action</a>
                   <div class="dropdown-divider"></div>
                   <a class="dropdown-item" href="#">Something else here</a>

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -16,7 +16,7 @@
               Tutors
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <a class="dropdown-item" href="#">Action</a>
+              <a class="dropdown-item" href="tutors/tutorsPage">Action</a>
               <a class="dropdown-item" href="#">Another action</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="#">Something else here</a>

--- a/src/main/resources/templates/rooms/roomsPage.html
+++ b/src/main/resources/templates/rooms/roomsPage.html
@@ -1,0 +1,83 @@
+
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Getting Started: Serving Web Content</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Tutors</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+      integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.4.1/css/all.css"
+      integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="../css/shards.min.css" />
+  </head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+    <div th:switch="${roomsModel}" class="container my-5">
+        <div class="row">
+          <div class="col-md-6">
+            <h2 th:case="null">No Rooms yet!</h2>
+            <div th:case="*">
+              <h2 class="my-5">Rooms</h2>
+              <table class="table table-striped table-responsive-md">
+                <thead>
+                  <tr>
+                    <th>Building Name</th>
+                    <th>Room Number</th>
+                    <th>Edit</th>
+                    <th>Delete</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr th:each="rm : ${roomsModel}">
+                    <td th:text="${rm.buildingname}"></td>
+                    <td th:text="${rm.roomNumber}"></td>
+                    <td>
+                      <a
+                        th:href="@{/rooms/edit/{id}(id=${rm.roomNumber})}"
+                        class="btn btn-primary"
+                        ><i class="fas fa-user-edit ml-2"></i
+                      ></a>
+                    </td>
+                    <td>
+                      <a
+                        th:href="@{/rooms/delete/{id}(id=${co.id})}"
+                        class="btn btn-primary"
+                        ><i class="fas fa-user-times ml-2"></i
+                      ></a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="my-5">
+              <a href="/rooms/create" class="btn btn-primary"
+                ><i class="fas fa-user-plus ml-2"></i
+              ></a>
+            </p>
+          </div>
+        </div>
+      </div>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
+</html>

--- a/src/main/resources/templates/timeSlots/timeSlotsPage.html
+++ b/src/main/resources/templates/timeSlots/timeSlotsPage.html
@@ -1,0 +1,86 @@
+
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Getting Started: Serving Web Content</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+    <!DOCTYPE html>
+    <html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Tutors</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+      integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.4.1/css/all.css"
+      integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="../css/shards.min.css" />
+  </head>
+    <div th:switch="${timeSlots}" class="container my-5">
+      <div class="row">
+        <div class="col-md-6">
+          <h2 th:case="null">No time slots yet!</h2>
+          <div th:case="*">
+            <h2 class="my-5">Time Slots</h2>
+            <table class="table table-striped table-responsive-md">
+              <thead>
+                <tr>
+                  <th>Start Time</th>
+                  <th>End Time</th>
+                  <th>Quarter</th>
+                  <th>Edit</th>
+                  <th>Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr th:each="timeSlot : ${timeSlots}">
+                  <td th:text="${timeSlot.startTime}"></td>
+                  <td th:text="${timeSlot.endTime}"></td>
+                  <td th:text="${timeSlot.quarter}"></td>
+                  <td>
+                    <a
+                      th:href="@{/timeSlots/edit/{id}(id=${timeSlot.id})}"
+                      class="btn btn-primary"
+                      ><i class="fas fa-user-edit ml-2"></i
+                    ></a>
+                  </td>
+                  <td>
+                    <a
+                      th:href="@{/timeSlots/delete/{id}(id=${timeSlot.id})}"
+                      class="btn btn-primary"
+                      ><i class="fas fa-user-times ml-2"></i
+                    ></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="my-5">
+            <a href="/timeSlots/create" class="btn btn-primary"
+              ><i class="fas fa-user-plus ml-2"></i
+            ></a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
+</html>

--- a/src/main/resources/templates/tutors/tutorsPage.html
+++ b/src/main/resources/templates/tutors/tutorsPage.html
@@ -1,0 +1,155 @@
+
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Getting Started: Serving Web Content</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+    <!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Tutors</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+      integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.4.1/css/all.css"
+      integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="../css/shards.min.css" />
+  </head>
+  <body>
+    <h1>Tutor Management System Proof of Concept</h1>
+    <div class="alert alert-danger" th:if="${errorIsAssignedQuarter}">
+      Cannot assign a tutor to more than one course in a given quarter!
+    </div>
+    <div class="alert alert-danger" th:if="${errorCourseExists}">
+      Cannot assign a tutor to more than one course in a given quarter!
+    </div>
+    <div th:switch="${tutors}" class="container my-5">
+      <div class="row">
+        <div class="col-md-6">
+          <h2 th:case="null">No tutors yet!</h2>
+          <div th:case="*">
+            <h2 class="my-5">Tutors</h2>
+            <table class="table table-striped table-responsive-md">
+              <thead>
+                <tr>
+                  <th>Id</th>
+                  <th>First Name</th>
+                  <th>Last Name</th>
+                  <th>Email</th>
+                  <th>Level</th>
+                  <th>Show</th>
+                  <th>Edit</th>
+                  <th>Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr th:each="tutor : ${tutors}">
+                  <td th:text="${tutor.id}"></td>
+                  <td th:text="${tutor.fname}"></td>
+                  <td th:text="${tutor.lname}"></td>
+                  <td th:text="${tutor.email}"></td>
+                  <td th:text="${tutor.level}"></td>
+                  <td>
+                    <a
+                      th:href="@{/tutors/show/{id}(id=${tutor.id})}"
+                      class="btn btn-primary"
+                      ><i class="fas fa-check ml-2"></i
+                    ></a>
+                  </td>
+                  <td>
+                    <a
+                      th:href="@{/tutors/edit/{id}(id=${tutor.id})}"
+                      class="btn btn-primary"
+                      ><i class="fas fa-user-edit ml-2"></i
+                    ></a>
+                  </td>
+                  <td>
+                    <a
+                      th:href="@{/tutors/delete/{id}(id=${tutor.id})}"
+                      class="btn btn-primary"
+                      ><i class="fas fa-user-times ml-2"></i
+                    ></a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="form-group row">
+            <label for="js-tutors" class="col-sm-2 col-form-label"></label>
+            <div class="col-sm-12">
+
+              <a href="/tutors/create" class="btn btn-primary"
+                ><i class="fas fa-user-plus ml-2"></i
+              ></a>
+
+              <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#uploadModal">Upload file <i class="fas fa-upload"></i
+              ></button>
+
+              <!-- Modal -->
+              <div id="uploadModal" class="modal fade" role="dialog">
+                <div class="modal-dialog">
+
+                  <!-- Modal content-->
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h4 class="modal-title">Upload CSV</h4>
+                      <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    </div>
+                    <div class="modal-body">
+                      <p>
+                        Please upload a CSV with the following fields:
+                      </p>
+                      <pre>
+id, firstname, lastname, email, level
+                      </pre>
+                      <!-- Form -->
+                      <form method='post' action='/tutorCSVUpload' enctype="multipart/form-data">
+                        <div class="input-group">
+                          <div class="custom-file">
+                            <input type="file" name='file' accept=".csv" class="custom-file-input" id="inputGroupFile01"
+                                   aria-describedby="inputGroupFileAddon01">
+                            <label class="custom-file-label" for="inputGroupFile01">Choose file</label>
+                          </div>
+                        </div>
+                        <br>
+                        <button type="submit" class="btn btn-primary">Upload <i class="fas fa-upload"></i
+                        ></button>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                      </form>
+                      <!-- Preview-->
+                      <div id='preview'></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <a href="/tutorCSVDownload" class="btn btn-primary"
+              >Download CSV<i class="fas fa-download"></i
+              ></a>
+            </div>
+        </div>
+      </div>
+    </div>
+
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
+</html>


### PR DESCRIPTION
Jacqueline Mai and Andrew Qi

* Moved all the tables to individual tabs
  * Tables are still present on index page, but can easily removed by deleting the line in `index.html` that yields to `basic-form.html`. 
  * Made some changes to the courseOffering page, which already existed before we started
   * Cleaned up the navbar so that the tabs are just links, rather than drop-downs with empty actions (this can be changed back when we want to add more actions later)